### PR TITLE
Added a button to get back to dashboard site from client site

### DIFF
--- a/ph-child.php
+++ b/ph-child.php
@@ -703,7 +703,8 @@ if ( ! class_exists( 'PH_Child' ) ) :
 				</style>
 				<?php
 				$connection = get_option( 'ph_child_parent_url', false );
-				$dashboard_url = $connection . '/wp-admin';
+				$site_id = (int) get_option( 'ph_child_id' );
+				$dashboard_url = $connection . '/wp-admin/post.php?post='. $site_id . '&action=edit';
 				$whitelabeld_plugin_name = get_option( 'ph_child_plugin_name', false );
 				if ( $connection ) {
 					/* translators: %s: parent site URL */

--- a/ph-child.php
+++ b/ph-child.php
@@ -698,7 +698,7 @@ if ( ! class_exists( 'PH_Child' ) ) :
 						background: #f1ebd3;
 					}
 					a.ph-admin-link {
-						margin-left: 15px !important;
+						margin-left: 10px !important;
 					}
 				</style>
 				<?php

--- a/ph-child.php
+++ b/ph-child.php
@@ -729,15 +729,6 @@ if ( ! class_exists( 'PH_Child' ) ) :
 							echo '<a class="button button-secondary ph-admin-link" target="_blank" href="' . esc_url( $dashboard_url ) . '">' . esc_html__( 'Visit Dashboard Site', 'project-huddle' ) . '</a>';
 						}
 					echo '</p>';
-					echo '<a class="button button-secondary ph-child-reload" href="' . esc_url(
-						add_query_arg(
-							array(
-								'ph-child-site-disconnect' => 1,
-								'ph-child-site-disconnect-nonce' => wp_create_nonce( 'ph-child-site-disconnect-nonce' ),
-							),
-							remove_query_arg( 'settings-updated' )
-						)
-					) . '">' . esc_html__( 'Disconnect', 'project-huddle' ) . '</a>';
 				} else {
 					echo '<p class="ph-badge ph-not-connected">';
 					esc_html_e( 'Not Connected. Please connect this plugin to your Feedback installation.', 'ph-child' );

--- a/ph-child.php
+++ b/ph-child.php
@@ -703,6 +703,8 @@ if ( ! class_exists( 'PH_Child' ) ) :
 				</style>
 				<?php
 				$connection = get_option( 'ph_child_parent_url', false );
+				$dashboard_url = $connection . '/wp-admin';
+				$whitelabeld_plugin_name = get_option( 'ph_child_plugin_name', false );
 				if ( $connection ) {
 					/* translators: %s: parent site URL */
 					echo '<p class="ph-badge ph-connected">' . sprintf( __( 'Connected to %s', 'ph-child' ), esc_url( $connection ) ) . '</p>';
@@ -717,9 +719,9 @@ if ( ! class_exists( 'PH_Child' ) ) :
 								remove_query_arg( 'settings-updated' )
 							)
 						) . '">' . esc_html__( 'Disconnect', 'project-huddle' ) . '</a>';
-
-						echo '<a class="button button-secondary ph-admin-link" href="">' . esc_html__( 'Visit Dashboard Site', 'project-huddle' ) . '</a>';
-
+						if( ! $whitelabeld_plugin_name ) {
+							echo '<a class="button button-secondary ph-admin-link" target="_blank" href="' . esc_url( $dashboard_url ) . '">' . esc_html__( 'Visit Dashboard Site', 'project-huddle' ) . '</a>';
+						}
 					echo '</p>';
 				} else {
 					echo '<p class="ph-badge ph-not-connected">';

--- a/ph-child.php
+++ b/ph-child.php
@@ -697,6 +697,9 @@ if ( ! class_exists( 'PH_Child' ) ) :
 						color: #9c8a44;
 						background: #f1ebd3;
 					}
+					a.ph-admin-link {
+						margin-left: 15px !important;
+					}
 				</style>
 				<?php
 				$connection = get_option( 'ph_child_parent_url', false );
@@ -704,15 +707,20 @@ if ( ! class_exists( 'PH_Child' ) ) :
 					/* translators: %s: parent site URL */
 					echo '<p class="ph-badge ph-connected">' . sprintf( __( 'Connected to %s', 'ph-child' ), esc_url( $connection ) ) . '</p>';
 					echo '<p class="submit">';
-					echo '<a class="button button-secondary" href="' . esc_url(
-						add_query_arg(
-							array(
-								'ph-child-site-disconnect' => 1,
-								'ph-child-site-disconnect-nonce' => wp_create_nonce( 'ph-child-site-disconnect-nonce' ),
-							),
-							remove_query_arg( 'settings-updated' )
-						)
-					) . '">' . esc_html__( 'Disconnect', 'project-huddle' ) . '</a>';
+
+						echo '<a class="button button-secondary" href="' . esc_url(
+							add_query_arg(
+								array(
+									'ph-child-site-disconnect' => 1,
+									'ph-child-site-disconnect-nonce' => wp_create_nonce( 'ph-child-site-disconnect-nonce' ),
+								),
+								remove_query_arg( 'settings-updated' )
+							)
+						) . '">' . esc_html__( 'Disconnect', 'project-huddle' ) . '</a>';
+
+						echo '<a class="button button-secondary ph-admin-link" href="">' . esc_html__( 'Visit Dashboard Site', 'project-huddle' ) . '</a>';
+
+					echo '</p>';
 				} else {
 					echo '<p class="ph-badge ph-not-connected">';
 					esc_html_e( 'Not Connected. Please connect this plugin to your Feedback installation.', 'ph-child' );

--- a/ph-child.php
+++ b/ph-child.php
@@ -716,7 +716,7 @@ if ( ! class_exists( 'PH_Child' ) ) :
 					/* translators: %s: parent site URL */
 					echo '<p class="ph-badge ph-connected">' . sprintf( __( 'Connected to %s', 'ph-child' ), esc_url( $connection ) ) . '</p>';
 					echo '<p class="submit">';
-						echo '<a class="button button-secondary" href="' . esc_url(
+						echo '<a class="button button-secondary ph-child-reload" href="' . esc_url(
 							add_query_arg(
 								array(
 									'ph-child-site-disconnect' => 1,


### PR DESCRIPTION
### Description
Added a button to get back to dashboard site from client site

### Screenshots
(https://share.getcloudapp.com/NQuN71Pg)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
 New feature (non-breaking change which adds functionality) 
<!-- Breaking change -->

### How has this been tested?
- Test on multisite - whene admin plugin is configured on a multisite
- Test on single site

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
