### PR TITLE
Rebranding plugin name as SureFeedback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "projecthuddle/ph-child",
-  	"description": "Collect note-style feedback from your client’s websites and sync them with your ProjectHuddle parent project.",
+  	"description": "Collect note-style feedback from your client’s websites and sync them with your SureFeedback parent project.",
   	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"phpcompatibility/phpcompatibility-wp": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "projecthuddle-child",
   "version": "1.0.34",
-  "description": "Collect note-style feedback from your client’s websites and sync them with your ProjectHuddle parent project",
+  "description": "Collect note-style feedback from your client’s websites and sync them with your SureFeedback parent project",
   "main": "index.js",
   "scripts": {
     "release": "sudo ./sync.sh --plugin-name='projecthuddle-child-site' --git-repo='https://github.com/ProjectHuddle/ph-child.git' --svn-user=2winfactor --assets-dir='screenshots'"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projecthuddle-child",
-  "version": "1.0.34",
+  "version": "1.1",
   "description": "Collect note-style feedback from your client’s websites and sync them with your SureFeedback parent project",
   "main": "index.js",
   "scripts": {

--- a/ph-child-functions.php
+++ b/ph-child-functions.php
@@ -94,7 +94,7 @@ function ph_child_flywheel_exclusions_notice() {
 	}
 
 	echo '<div class="notice notice-info is-dismissible ph-notice" data-notice="ph-flywheel-child">
-			<p><strong>ProjectHuddle:</strong> ' . esc_html( sprintf( __( 'Flywheel hosting detected!  You\'ll need to request a cache exclusion in order for project access links to work correctly.', 'ph-child' ) ) ) . '</p>
+			<p><strong>SureFeedback:</strong> ' . esc_html( sprintf( __( 'Flywheel hosting detected!  You\'ll need to request a cache exclusion in order for project access links to work correctly.', 'ph-child' ) ) ) . '</p>
 			<p><a href="https://help.projecthuddle.com/article/229-flywheel-client-site-cache-exclusions" target="_blank">Learn More</a></p>
 		</div>';
 	ph_child_dismiss_js();
@@ -118,7 +118,7 @@ function ph_child_wpengine_exclusions_notice() {
 	}
 
 	echo '<div class="notice notice-info is-dismissible ph-notice" data-notice="ph-wp-engine-child">
-			<p><strong>ProjectHuddle:</strong> ' . esc_html( sprintf( __( 'WPEngine hosting detected!  You\'ll need to request a cache exclusion in order for ProjectHuddle access links to work properly.', 'ph-child' ) ) ) . '</p>
+			<p><strong>SureFeedback:</strong> ' . esc_html( sprintf( __( 'WPEngine hosting detected!  You\'ll need to request a cache exclusion in order for SureFeedback access links to work properly.', 'ph-child' ) ) ) . '</p>
 			<p><a href="https://help.projecthuddle.com/article/228-wpengine-client-site-plugin-exclusions" target="_blank">Learn More</a></p>
 		</div>';
 	ph_child_dismiss_js();

--- a/ph-child.php
+++ b/ph-child.php
@@ -5,7 +5,7 @@
  * Description: Collect note-style feedback from your client’s websites and sync them with your SureFeedback parent project.
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
- * Version: 1.0.34
+ * Version: 1.1
  *
  * Requires at least: 4.7
  * Tested up to: 6.3

--- a/ph-child.php
+++ b/ph-child.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name: ProjectHuddle Client Site
- * Plugin URI: http://projecthuddle.com
- * Description: Collect note-style feedback from your client’s websites and sync them with your ProjectHuddle parent project.
+ * Plugin Name: SureFeedback Client Site
+ * Plugin URI: http://surefeedback.com
+ * Description: Collect note-style feedback from your client’s websites and sync them with your SureFeedback parent project.
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Version: 1.0.34
@@ -13,7 +13,7 @@
  * Text Domain: ph-child
  * Domain Path: languages
  *
- * @package ProjectHuddle Child
+ * @package SureFeedback Child
  * @author Brainstorm Force, Andre Gagnon
  */
 
@@ -196,7 +196,7 @@ if ( ! class_exists( 'PH_Child' ) ) :
 		 * Show parent plugin activation notice.
 		 */
 		public function parent_plugin_activated_error_notice() {
-			$message = __( 'You have both the client site and ProjectHuddle core plugins activated. You must only activate the client site on a client site, and ProjectHuddle on your main site.', 'project-huddle' );
+			$message = __( 'You have both the client site and SureFeedback core plugins activated. You must only activate the client site on a client site, and SureFeedback on your main site.', 'project-huddle' );
 			echo '<div class="error"> <p>' . esc_html( $message ) . '</p></div>';
 		}
 
@@ -246,13 +246,13 @@ if ( ! class_exists( 'PH_Child' ) ) :
 			// make the changes to the text.
 			if ( 'ph-child' === $domain ) { // added this check to avoid conflicting other plugins.
 				switch ( $untranslated_text ) {
-					case 'ProjectHuddle Client Site':
+					case 'SureFeedback Client Site':
 						$name = get_option( 'ph_child_plugin_name', false );
 						if ( $name ) {
 							$translated_text = $name;
 						}
 						break;
-					case 'Collect note-style feedback from your client’s websites and sync them with your ProjectHuddle parent project.':
+					case 'Collect note-style feedback from your client’s websites and sync them with your SureFeedback parent project.':
 						$description = get_option( 'ph_child_plugin_description', false );
 						if ( $description ) {
 							$translated_text = $description;
@@ -373,7 +373,7 @@ if ( ! class_exists( 'PH_Child' ) ) :
 			$plugin_name = get_option( 'ph_child_plugin_name', false );
 			add_options_page(
 				__( 'Feedback Connection', 'ph-child' ),
-				$plugin_name ? esc_html( $plugin_name ) : __( 'ProjectHuddle', 'ph-child' ),
+				$plugin_name ? esc_html( $plugin_name ) : __( 'SureFeedback', 'ph-child' ),
 				'manage_options',
 				'feedback-connection-options',
 				array( $this, 'options_page' )
@@ -818,7 +818,7 @@ if ( ! class_exists( 'PH_Child' ) ) :
 					<h1>
 					<?php
 						$plugin_name = get_option( 'ph_child_plugin_name', false );
-						echo $plugin_name ? esc_html( $plugin_name . ' Options' ) : esc_html__( 'ProjectHuddle Options', 'ph-child' );
+						echo $plugin_name ? esc_html( $plugin_name . ' Options' ) : esc_html__( 'SureFeedback Options', 'ph-child' );
 					?>
 						</h1>
 
@@ -931,12 +931,12 @@ if ( ! class_exists( 'PH_Child' ) ) :
 			// settings must be set.
 			$url = get_option( 'ph_child_parent_url' );
 			if ( ! $url ) {
-				echo '<!-- ProjectHuddle: parent url not set -->';
+				echo '<!-- SureFeedback: parent url not set -->';
 				return;
 			}
 			$id = get_option( 'ph_child_id' );
 			if ( ! $id ) {
-				echo '<!-- ProjectHuddle: project id not set -->';
+				echo '<!-- SureFeedback: project id not set -->';
 				return;
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://surefeedback.com
 Tags: project, huddle, child, feedback, design, approval
 Requires at least: 4.7
 Tested up to: 6.3
-Stable tag: 1.0.34
+Stable tag: 1.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -47,6 +47,9 @@ All you need to do is install the plugin on the site you want feedback on and it
 The purpose of this plugin is to make it simple to get targeted feedback from clients on web designs. All you have to do is install the [SureFeedback](https://surefeedback.com) plugin and let your clients select areas of your design to add their own comments. Everything is tracked within the plugin. It's so easy to use!
 
 == Changelog ==
+= 1.1 =
+* Rebranding ProjectHuddle as SureFeedback.
+
 = 1.0.34 =
 * Improvement: Compatibility to WordPress 6.3
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-=== ProjectHuddle Client Site ===
+=== SureFeedback Client Site ===
 Contributors: brainstormforce, 2winfactor
-Donate link: https://projecthuddle.com
+Donate link: https://surefeedback.com
 Tags: project, huddle, child, feedback, design, approval
 Requires at least: 4.7
 Tested up to: 6.3
@@ -9,25 +9,25 @@ Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Provides a secure connection between your ProjectHuddle parent site and your client sites, syncing identities so clients can use their WordPress identities for commenting.
+Provides a secure connection between your SureFeedback parent site and your client sites, syncing identities so clients can use their WordPress identities for commenting.
 
 == Description ==
 
-This is the Child plugin for [ProjectHuddle](https://projecthuddle.com)
+This is the Child plugin for [SureFeedback](https://surefeedback.com)
 
-The ProjectHuddle plugin lets you collect sticky note-style feedback on page designs and web projects. It’s so easy to use. Clients can select specific areas of your design, point, click, and type constructive comments on top of your mockups and site designs.
+The SureFeedback plugin lets you collect sticky note-style feedback on page designs and web projects. It’s so easy to use. Clients can select specific areas of your design, point, click, and type constructive comments on top of your mockups and site designs.
 
-Using ProjectHuddle, the client can show as well as tell, providing targeted feedback for a more efficient workflow. 
+Using SureFeedback, the client can show as well as tell, providing targeted feedback for a more efficient workflow. 
 
-ProjectHuddle is a self-hosted client feedback system that allows you to get feedback on an endless amount of client sites from one central dashboard.
+SureFeedback is a self-hosted client feedback system that allows you to get feedback on an endless amount of client sites from one central dashboard.
 
-The [ProjectHuddle](https://projecthuddle.com) Client Site plugin is used to securely sync multiple WordPress client identities with your ProjectHuddle parent site.
+The [SureFeedback](https://surefeedback.com) Client Site plugin is used to securely sync multiple WordPress client identities with your SureFeedback parent site.
 
 All you need to do is install the plugin on the site you want feedback on and it's ready to go.
 
 **Features include:**
 
-* Connect and sync your client’s identities with your ProjectHuddle projects.
+* Connect and sync your client’s identities with your SureFeedback projects.
 * No login or registration is required if your client is logged into their own site.
 * Choose which roles you want to allow for commenting.
 * Allow non-users (guests) to leave comments.
@@ -36,15 +36,15 @@ All you need to do is install the plugin on the site you want feedback on and it
 
 == Installation ==
 
-1. Go to `Plugins -> Add New` and search for ProjectHuddle Client Site
+1. Go to `Plugins -> Add New` and search for SureFeedback Client Site
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Go to `Settings -> ProjectHuddle` to configure the plugin options.
+3. Go to `Settings -> SureFeedback` to configure the plugin options.
 
 == Frequently Asked Questions ==
 
 = What is the purpose of this plugin? =
 
-The purpose of this plugin is to make it simple to get targeted feedback from clients on web designs. All you have to do is install the [ProjectHuddle](https://projecthuddle.com) plugin and let your clients select areas of your design to add their own comments. Everything is tracked within the plugin. It's so easy to use!
+The purpose of this plugin is to make it simple to get targeted feedback from clients on web designs. All you have to do is install the [SureFeedback](https://surefeedback.com) plugin and let your clients select areas of your design to add their own comments. Everything is tracked within the plugin. It's so easy to use!
 
 == Changelog ==
 = 1.0.34 =
@@ -61,7 +61,7 @@ The purpose of this plugin is to make it simple to get targeted feedback from cl
 = 1.0.31 =
 * Improvement: Added "Visit Dashboard Site" button on the connection page.
 * Improvement: Allow Guests to Comment setting text changed as Allow Site Visitors to view and add comments.
-* Improvement: Renamed settings menu title from "Feedback" to "ProjectHuddle" and added white label support.
+* Improvement: Renamed settings menu title from "Feedback" to "SureFeedback" and added white label support.
 * Improvement: Connection details input box disabled after connection is established.
 
 = 1.0.30 =
@@ -126,7 +126,7 @@ The purpose of this plugin is to make it simple to get targeted feedback from cl
 * Fix cookie expiration date
 
 = 1.0.8 =
-* Allow access links to load comment interface (must use ProjectHuddle 3.6.17+)
+* Allow access links to load comment interface (must use SureFeedback 3.6.17+)
 
 = 1.0.7 =
 * Defer script to not interfere with html parser in older browsers

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Uninstall ProjectHuddle Child Pkugin
+ * Uninstall SureFeedback Child Plugin
  *
  * Deletes all the plugin data
  *
- * @package     ProjectHuddle Child
+ * @package     SureFeedback Child
  * @subpackage  Uninstall
  * @copyright   Copyright (c) 2016, Andre Gagnon
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License


### PR DESCRIPTION
### Description
Rebranding plugin name as SureFeedback

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
